### PR TITLE
Exclude .gitignore’d Files from Tests and Scripts

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -26,4 +26,12 @@ See the full checklist and principles in [claude_coding_best_practices.md](claud
 - Use the checklist as part of your development and review workflow.
 - If you see areas where the repo does not yet meet these standards, please raise an issue or PR.
 
+---
+
+## File Inclusion Policy
+
+**Note:** Only files tracked by git (i.e., not ignored by `.gitignore`) are processed by tests and project scripts.  
+If your files are not added to git, they will be skipped by all automated linting, formatting, and testing tools.  
+To ensure your new or modified files are included, use `git add` before running tests or submitting a pull request.
+
 Thank you for helping us maintain high standards!

--- a/fix_all_files.py
+++ b/fix_all_files.py
@@ -8,56 +8,18 @@ from pathlib import Path
 from typing import List, Optional
 
 
-def find_python_files(ignore_patterns: Optional[List[str]] = None) -> List[str]:
-    """Find all Python files in the current directory and subdirectories."""
-    if ignore_patterns is None:
-        # Default patterns to ignore - include both slash types for cross-platform
-        # compatibility
-        ignore_patterns = [
-            r"\.git[/\\]",
-            r"\.venv[/\\]",
-            r"venv[/\\]",
-            r"__pycache__[/\\]",
-            r"\.pytest_cache[/\\]",
-            r"\.mypy_cache[/\\]",
-            r"\.ruff_cache[/\\]",
-            r"\.eggs[/\\]",
-            r"\.tox[/\\]",
-            r"build[/\\]",
-            r"dist[/\\]",
-            r".*\.egg-info[/\\]",
-        ]
-
-    python_files = []
-    for root, dirs, files in os.walk("."):
-        # Skip directories that match ignore patterns
-        # Convert paths to use forward slashes for consistency in pattern matching
-        dirs[:] = [
-            d
-            for d in dirs
-            if not any(
-                re.search(pattern, os.path.join(root, d).replace("\\", "/"))
-                for pattern in ignore_patterns
-            )
-        ]
-
-        # Also explicitly remove .venv directory if it exists
-        if ".venv" in dirs:
-            dirs.remove(".venv")
-        if "venv" in dirs:
-            dirs.remove("venv")
-
-        for file in files:
-            if file.endswith(".py"):
-                file_path = os.path.join(root, file)
-                # Check if the file path matches any ignore pattern
-                if not any(
-                    re.search(pattern, file_path.replace("\\", "/"))
-                    for pattern in ignore_patterns
-                ):
-                    python_files.append(file_path)
-
-    return python_files
+def find_python_files() -> List[str]:
+    """Find all Python files tracked by git (not ignored by .gitignore)."""
+    try:
+        # Use git ls-files to get all *.py files tracked by git
+        output = (
+            os.popen("git ls-files '*.py'").read()
+        )
+        python_files = [line.strip() for line in output.splitlines() if line.strip()]
+        return python_files
+    except Exception as e:
+        print(f"Error finding git-tracked Python files: {e}")
+        return []
 
 
 def fix_file(file_path: str, verbose: bool = False) -> bool:

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1,7 +1,34 @@
-"""conftest - Module for tests.conftest."""
+"""conftest - Module for tests.conftest.
 
-# Standard library imports
+Ensures that pytest does not collect or execute any files or directories ignored by .gitignore.
+"""
 
-# Third-party imports
+import subprocess
+import os
+import pytest
 
-# Local imports
+def is_git_tracked(path):
+    """Return True if the file is tracked by git (not ignored), False otherwise."""
+    try:
+        # Use git ls-files to check if the file is tracked (not ignored)
+        # --error-unmatch causes non-tracked files to raise an error
+        subprocess.check_output(
+            ["git", "ls-files", "--error-unmatch", os.path.relpath(path)], stderr=subprocess.DEVNULL
+        )
+        return True
+    except subprocess.CalledProcessError:
+        return False
+
+def pytest_collect_file(parent, path):
+    """Hook called by pytest for every file considered for collection.
+
+    Skips files that are not tracked by git (i.e., are git-ignored).
+    """
+    # Only apply check to files (not directories)
+    if path.isfile():
+        abspath = str(path)
+        if not is_git_tracked(abspath):
+            # Skip collection of ignored/untracked files
+            return None
+    # Let pytest handle normal collection
+    # Returning None means normal behavior if not ignored

--- a/verify_tracked_files.py
+++ b/verify_tracked_files.py
@@ -1,0 +1,50 @@
+#!/usr/bin/env python
+"""
+verify_tracked_files.py
+
+CI utility: Ensures only git-tracked (non-.gitignore'd) Python files are present in the repository.
+Fails if any untracked or ignored Python files are found, which could otherwise be processed by scripts or tests.
+
+Usage:
+    python verify_tracked_files.py
+"""
+
+import os
+import sys
+
+def get_git_tracked_files():
+    """Return a set of all Python files tracked by git."""
+    output = os.popen("git ls-files '*.py'").read()
+    tracked = set(line.strip() for line in output.splitlines() if line.strip())
+    return tracked
+
+def get_all_python_files():
+    """Return a set of all Python files found in the repo (excluding .git directory)."""
+    all_files = set()
+    for root, dirs, files in os.walk("."):
+        # Skip .git and common virtualenv dirs
+        dirs[:] = [d for d in dirs if d not in {".git", ".venv", "venv", "__pycache__"}]
+        for file in files:
+            if file.endswith(".py"):
+                # Normalize to relative path
+                relpath = os.path.relpath(os.path.join(root, file))
+                all_files.add(relpath)
+    return all_files
+
+def main():
+    tracked = get_git_tracked_files()
+    all_found = get_all_python_files()
+    untracked = sorted(f for f in all_found if f not in tracked)
+
+    if untracked:
+        print("ERROR: The following Python files are NOT tracked by git (and may be ignored by .gitignore):")
+        for f in untracked:
+            print(f"  {f}")
+        print("\nTo fix: either add these files to git, or remove/move them so they are not discovered by scripts/tests.")
+        sys.exit(1)
+    else:
+        print("All discovered Python files are tracked by git (not ignored).")
+        sys.exit(0)
+
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION
This pull request addresses issue #73 by updating the project to exclude files and directories listed in `.gitignore` from tests and scripts. Key changes include:

1. **Documentation Update**: Added a section in `CONTRIBUTING.md` to inform contributors that only files tracked by git will be processed by tests and scripts.

2. **Script Modification**: The `find_python_files` function in `fix_all_files.py` has been modified to utilize `git ls-files` to only retrieve Python files that are tracked by git, ensuring ignored files are excluded.

3. **Test Configuration**: Updated `tests/conftest.py` to implement a check that prevents pytest from collecting files that are not tracked by git.

4. **CI Utility**: Introduced `verify_tracked_files.py`, a new script that checks for any untracked or ignored Python files in the repository, ensuring that only tracked files are processed.

These changes enhance the integrity of the testing and scripting processes by ensuring that only relevant files are included.

---

> This pull request was co-created with Cosine Genie

Original Task: [pAIssive_income/jdbqru09qrvd](https://cosine.sh/erdv7z5xbu2c/pAIssive_income/task/jdbqru09qrvd)
Author: Alex Chapin
