### PR TITLE
fix: Remove obsolete version field from docker-compose.yml files

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,5 +1,3 @@
-version: '3.8'
-
 services:
   app:
     build:

--- a/docs/deployment_guide.md
+++ b/docs/deployment_guide.md
@@ -82,8 +82,6 @@ The deployment process assumes that your servers are set up with Docker and Dock
 ### Example docker-compose.yml
 
 ```yaml
-version: '3.8'
-
 services:
   app:
     image: paissiveincome/app:latest

--- a/services/message_queue_service/docker-compose.yml
+++ b/services/message_queue_service/docker-compose.yml
@@ -1,5 +1,3 @@
-version: '3.8'
-
 services:
   rabbitmq:
     image: rabbitmq:3-management


### PR DESCRIPTION
This PR fixes the issue with the Docker Compose integration workflow failing due to the obsolete `version` field in the docker-compose.yml files.

## Changes
- Removed the `version: '3.8'` field from the main docker-compose.yml file
- Removed the `version: '3.8'` field from the services/message_queue_service/docker-compose.yml file

## Why
The `version` field is now considered obsolete in Docker Compose v2.x. Including it causes warnings and potential issues in CI workflows. The updated docker-compose.yml files rely on the Compose specification, which is automatically inferred.

This should resolve the warning:
```
/home/runner/work/pAIssive_income/pAIssive_income/docker-compose.yml: `version` is obsolete
```

## Testing
The Docker Compose integration workflow should now pass without warnings about the obsolete version field.