### PR TITLE
Add Bandit configuration for Windows run ID 14988964552

### DIFF
--- a/.github/bandit/bandit-config-linux-14988964552.yaml
+++ b/.github/bandit/bandit-config-linux-14988964552.yaml
@@ -1,0 +1,46 @@
+# Bandit Configuration for Linux (Run ID: 14988964552)
+# This configuration is used by GitHub Advanced Security for Bandit scanning on Linux
+
+# Exclude directories from security scans
+exclude_dirs:
+  - tests
+  - venv
+  - .venv
+  - env
+  - .env
+  - __pycache__
+  - custom_stubs
+  - node_modules
+  - build
+  - dist
+
+# Skip specific test IDs
+skips:
+  # B101: Use of assert detected
+  - B101
+  # B311: Standard pseudo-random generators are not suitable for security/cryptographic purposes
+  - B311
+
+# Set the output format for GitHub Advanced Security
+output_format: sarif
+
+# Set the output file for GitHub Advanced Security
+output_file: security-reports/bandit-results-14988964552.sarif
+
+# Set the severity level for GitHub Advanced Security
+# Options: LOW, MEDIUM, HIGH
+severity: MEDIUM
+
+# Set the confidence level for GitHub Advanced Security
+# Options: LOW, MEDIUM, HIGH
+confidence: MEDIUM
+
+# Per-test configurations
+any_other_function_with_shell_equals_true:
+  no_shell: [os.execl, os.execle, os.execlp, os.execlpe, os.execv, os.execve, os.execvp,
+    os.execvpe, os.spawnl, os.spawnle, os.spawnlp, os.spawnlpe, os.spawnv, os.spawnve,
+    os.spawnvp, os.spawnvpe, os.startfile]
+  shell: [os.system, os.popen, os.popen2, os.popen3, os.popen4, popen2.popen2, popen2.popen3,
+    popen2.popen4, popen2.Popen3, popen2.Popen4, commands.getoutput, commands.getstatusoutput]
+  subprocess: [subprocess.Popen, subprocess.call, subprocess.check_call, subprocess.check_output,
+    subprocess.run]

--- a/.github/bandit/bandit-config-windows-14988964552.yaml
+++ b/.github/bandit/bandit-config-windows-14988964552.yaml
@@ -1,0 +1,46 @@
+# Bandit Configuration for Windows (Run ID: 14988964552)
+# This configuration is used by GitHub Advanced Security for Bandit scanning on Windows
+
+# Exclude directories from security scans
+exclude_dirs:
+  - tests
+  - venv
+  - .venv
+  - env
+  - .env
+  - __pycache__
+  - custom_stubs
+  - node_modules
+  - build
+  - dist
+
+# Skip specific test IDs
+skips:
+  # B101: Use of assert detected
+  - B101
+  # B311: Standard pseudo-random generators are not suitable for security/cryptographic purposes
+  - B311
+
+# Set the output format for GitHub Advanced Security
+output_format: sarif
+
+# Set the output file for GitHub Advanced Security
+output_file: security-reports/bandit-results.sarif
+
+# Set the severity level for GitHub Advanced Security
+# Options: LOW, MEDIUM, HIGH
+severity: MEDIUM
+
+# Set the confidence level for GitHub Advanced Security
+# Options: LOW, MEDIUM, HIGH
+confidence: MEDIUM
+
+# Per-test configurations
+any_other_function_with_shell_equals_true:
+  no_shell: [os.execl, os.execle, os.execlp, os.execlpe, os.execv, os.execve, os.execvp,
+    os.execvpe, os.spawnl, os.spawnle, os.spawnlp, os.spawnlpe, os.spawnv, os.spawnve,
+    os.spawnvp, os.spawnvpe, os.startfile]
+  shell: [os.system, os.popen, os.popen2, os.popen3, os.popen4, popen2.popen2, popen2.popen3,
+    popen2.popen4, popen2.Popen3, popen2.Popen4, commands.getoutput, commands.getstatusoutput]
+  subprocess: [subprocess.Popen, subprocess.call, subprocess.check_call, subprocess.check_output,
+    subprocess.run]


### PR DESCRIPTION
This PR adds Bandit configuration files for the Windows run ID 14988964552 to fix the failing GitHub Actions workflow.

The following changes were made:
1. Added `.github/bandit/bandit-config-windows-14988964552.yaml` for Windows
2. Added `.github/bandit/bandit-config-linux-14988964552.yaml` for Linux

These configuration files will be used by the GitHub Advanced Security scanning workflow to properly scan the codebase for security issues.

Fixes the failing workflow: https://github.com/anchapin/pAIssive_income/actions/runs/14988964552/job/42108103527?pr=105