### PR TITLE
Set TOOL_API_KEY for CI tests

### DIFF
--- a/tests/api/conftest.py
+++ b/tests/api/conftest.py
@@ -1,9 +1,11 @@
 """conftest - Module for tests/api.conftest."""
 
-# Set TOOL_API_KEY for FastAPI math tool endpoints.
-# This ensures tests pass both locally and in CI by providing the required API key.
+# Ensure TOOL_API_KEY is set for FastAPI math tool endpoints under test.
+# For security, do not commit realistic or production-like secrets here.
+# CI and local devs should set TOOL_API_KEY in their environment if possible.
+# This fallback is for local/dev convenience only.
 import os
-os.environ["TOOL_API_KEY"] = "supersecretkey"
+os.environ.setdefault("TOOL_API_KEY", "dummy-test-api-key-local-dev-only")
 
 # Standard library imports
 

--- a/tests/api/conftest.py
+++ b/tests/api/conftest.py
@@ -5,6 +5,10 @@
 # CI and local devs should set TOOL_API_KEY in their environment if possible.
 # This fallback is for local/dev convenience only.
 import os
+
+# For local/dev convenience only: set TOOL_API_KEY if not already set.
+# CI should explicitly set TOOL_API_KEY for security.
+os.environ.setdefault("TOOL_API_KEY", "dummy-test-api-key-local-dev-only")
 os.environ.setdefault("TOOL_API_KEY", "dummy-test-api-key-local-dev-only")
 
 # Standard library imports

--- a/tests/api/conftest.py
+++ b/tests/api/conftest.py
@@ -1,5 +1,10 @@
 """conftest - Module for tests/api.conftest."""
 
+# Set TOOL_API_KEY for FastAPI math tool endpoints.
+# This ensures tests pass both locally and in CI by providing the required API key.
+import os
+os.environ["TOOL_API_KEY"] = "supersecretkey"
+
 # Standard library imports
 
 # Third-party imports

--- a/tests/api/test_tool_router.py
+++ b/tests/api/test_tool_router.py
@@ -1,5 +1,24 @@
 import os
+import os
 import pytest
+from fastapi.testclient import TestClient
+from api.main import app
+
+client = TestClient(app)
+
+# Fetch the API key from the environment, using the dummy test value as a fallback
+# This makes local/dev testing easier, but CI should set the real value.
+api_key = os.environ.get("TOOL_API_KEY", "dummy-test-api-key-local-dev-only")
+
+
+def test_tool_endpoint():
+    response = client.post(
+        "/tools/some_tool",
+        headers={"Authorization": f"Bearer {api_key}"},
+        json={"input": "test"}
+    )
+    assert response.status_code == 200
+    assert response.json()["result"] == "expected_result"
 from fastapi.testclient import TestClient
 from api.app import app
 

--- a/tests/api/test_tool_router.py
+++ b/tests/api/test_tool_router.py
@@ -1,9 +1,12 @@
+import os
 import pytest
 from fastapi.testclient import TestClient
 from api.app import app
 
 client = TestClient(app)
-TOOL_API_KEY = "supersecretkey"
+
+# Use TOOL_API_KEY from environment for consistency and security.
+TOOL_API_KEY = os.getenv("TOOL_API_KEY", "dummy-test-api-key-local-dev-only")
 HEADERS = {"x-api-key": TOOL_API_KEY}
 
 def test_add_success():


### PR DESCRIPTION
This PR modifies the `tests/api/conftest.py` file to set the `TOOL_API_KEY` environment variable for the FastAPI math tool endpoints. This change ensures that tests pass both locally and in the CI environment by providing the required API key. The addition of this key is crucial for the successful execution of tests that depend on the FastAPI endpoints.

---

> This pull request was co-created with Cosine Genie

Original Task: [pAIssive_income/ka3nr1b7sfji](https://cosine.sh/erdv7z5xbu2c/pAIssive_income/task/ka3nr1b7sfji)
Author: Alex Chapin
