### PR TITLE
Fix API Key Exposure in config.toml

### DIFF
--- a/config.toml
+++ b/config.toml
@@ -118,8 +118,8 @@ max_concurrent_conversations = 5
 # AWS secret access key
 #aws_secret_access_key = ""
 
-# API key to use (For Headless / CLI only -  In Web this is overridden by Session Init)
-api_key = "AIzaSyBNnOzOE-WDyp8Tm0B1qQntBTcaJ30OLO8"
+# API key to use (For Headless / CLI only - In Web this is overridden by Session Init)
+# api_key = "${GOOGLE_API_KEY}"  # Set via environment variable; do not commit secrets.
 
 # API base URL (For Headless / CLI only -  In Web this is overridden by Session Init)
 #base_url = ""


### PR DESCRIPTION
This pull request addresses issue #287 regarding potential API key exposure in the `config.toml` file. The API key for GoogleGemini has been commented out and replaced with a template that encourages the use of environment variables for security. 

Changes made:
- The line containing the actual API key has been commented out to prevent exposure.
- A note has been added to instruct users to set the API key via an environment variable (`GOOGLE_API_KEY`) instead of committing sensitive information directly into the repository.

These changes help to secure the repository by ensuring sensitive credentials are not exposed.

---

> This pull request was co-created with Cosine Genie

Original Task: [pAIssive_income/jr44gb7b2x9l](https://cosine.sh/erdv7z5xbu2c/pAIssive_income/task/jr44gb7b2x9l)
Author: Alex Chapin
